### PR TITLE
Change to using Github repository Int64 id as Repository model @ID

### DIFF
--- a/Sources/App/Concurrency/DatabaseActor.swift
+++ b/Sources/App/Concurrency/DatabaseActor.swift
@@ -17,7 +17,7 @@ actor DatabaseActor {
     private func _addRepository(_ repository: GithubAPIClient.Repository, logger: Logger, database: any Database) async throws {
         // Query to see if we already a repository with this Github repository id
         let repositoryWithIdCount = try await Repository.query(on: database)
-            .filter(\.$gitHubId == repository.id)
+            .filter(\.$id == repository.id)
             .count()
         guard repositoryWithIdCount == 0 else {
             logger.debug("Repository with id=\(repository.id) already exists in database. Skipping database add.")
@@ -25,7 +25,7 @@ actor DatabaseActor {
         }
 
         let repositoryToAdd = Repository(
-            gitHubId: repository.id,
+            id: repository.id,
             htmlUrl: repository.htmlURL,
             cloneUrl: repository.cloneURL,
             sshUrl: repository.sshURL

--- a/Sources/App/Controllers/PackageRegistryController+FetchPackageID.swift
+++ b/Sources/App/Controllers/PackageRegistryController+FetchPackageID.swift
@@ -16,7 +16,7 @@ extension PackageRegistryController {
     ) async throws -> String? {
         logger.debug("Checking DB for repository with URL \"\(githubURL)\"")
         if let repositoryFromDB = try await Self.repositoryFromDB(for: githubURL, on: database) {
-            logger.debug("Found DB repository id=\(repositoryFromDB.gitHubId). Returning \(githubURL.packageIdentifier)")
+            logger.debug("Found DB repository id=\(String(describing: repositoryFromDB.id)). Returning \(githubURL.packageIdentifier)")
             return githubURL.packageIdentifier
         }
 

--- a/Sources/App/Database/Migrations/CreateRepositories.swift
+++ b/Sources/App/Database/Migrations/CreateRepositories.swift
@@ -3,8 +3,7 @@ import Fluent
 struct CreateRepositories: AsyncMigration {
     func prepare(on database: Database) async throws {
         try await database.schema("repositories")
-            .id()
-            .field("github_id", .int64)
+            .field("id", .int64, .identifier(auto: false))
             .field("html_url", .string)
             .field("clone_url", .string)
             .field("ssh_url", .string)

--- a/Sources/App/Database/Models/Repository.swift
+++ b/Sources/App/Database/Models/Repository.swift
@@ -5,12 +5,8 @@ import Vapor
 final class Repository: Model, @unchecked Sendable {
     static let schema = "repositories"
 
-    @ID(key: .id)
-    var id: UUID?
-
-    // This is the id returned from the Github API
-    @Field(key: "github_id")
-    var gitHubId: Int64
+    @ID(custom: .id, generatedBy: .user)
+    var id: Int64?
 
     @Field(key: "html_url")
     var htmlUrl: String
@@ -24,14 +20,12 @@ final class Repository: Model, @unchecked Sendable {
     init() { }
 
     init(
-        id: UUID? = nil,
-        gitHubId: Int64,
+        id: Int64,
         htmlUrl: String,
         cloneUrl: String,
         sshUrl: String
     ) {
         self.id = id
-        self.gitHubId = gitHubId
         self.htmlUrl = htmlUrl
         self.cloneUrl = cloneUrl
         self.sshUrl = sshUrl


### PR DESCRIPTION
In the previous PR where we started using a DB as cache for the `/identifiers?url=` endpoint, @saturninocollaco made [this comment](https://github.com/CrowdStrike/swift-package-registry-service/pull/4#discussion_r2010761316), suggesting that we use the `Int64` returned by the GithubAPI `GET /repos/{owner}/{repo}` endpoint as the Fluent model `@ID`.

At first, I thought we shouldn't do this, as it would be incompatible with the NoSQL Fluent driver. But the more I thought about it, the more I thought this was a good idea. I don't think we would ever use the NoSQL drivers, as our data is inherently suited to table-based SQL-type databases. We might eventually move to PostgreSQL, but I don't think we would ever move to NoSQL.

So this PR implements Nino's suggestion from the previous PR. The screenshot belows shows the SQLite database after making several calls to the `/identifiers?url=` endpoint.

<img width="1840" alt="Screenshot 2025-03-25 at 9 31 06 AM" src="https://github.com/user-attachments/assets/d4d7af27-8e3e-42c9-9162-ccdb6c73a845" />

