### PR TITLE
Add helper scripts

### DIFF
--- a/scripts/github-api-get-contents-file.sh
+++ b/scripts/github-api-get-contents-file.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Calls the "Get Repository Content" Github API operation
+# https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content
+#
+
+set -euo pipefail
+
+if [[ -z "${GITHUB_API_TOKEN+x}" ]]; then
+    echo "The environment variable GITHUB_API_TOKEN is not set."
+    echo "Please set GITHUB_API_TOKEN to the value of a Github Personal Access Token and retry."
+    exit 1
+fi
+
+if [ $# -lt 4 ] || [ $# -gt 4 ]; then
+    echo "Usage: $0 <owner> <repo> <tag> <file>"
+    echo
+    echo "where:"
+    echo "   <owner>: The repository scope organization. (required)"
+    echo "    <repo>: The repository name. (required)"
+    echo "     <tag>: The repository tag. (required)"
+    echo "    <file>: The file name in the repository root. (required)"
+    echo
+    echo "Examples:"
+    echo "    $0 pointfreeco swift-composable-architecture 1.18.0 Package.swift"
+    exit 1
+fi
+
+URL="https://api.github.com/repos/$1/$2/contents/$4?ref=$3"
+
+curl -H "X-GitHub-Api-Version: 2022-11-28" \
+     -H "Accept: application/vnd.github.object+json" \
+     -H "Authorization: Bearer $GITHUB_API_TOKEN" \
+     --no-progress-meter \
+     $URL

--- a/scripts/github-api-get-contents-root-directory.sh
+++ b/scripts/github-api-get-contents-root-directory.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Calls the "Get Repository Content" Github API operation
+# https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content
+#
+# Note that this script calls the endpoint with a <path> of "", meaning
+# the root of the repository.
+
+set -euo pipefail
+
+if [[ -z "${GITHUB_API_TOKEN+x}" ]]; then
+    echo "The environment variable GITHUB_API_TOKEN is not set."
+    echo "Please set GITHUB_API_TOKEN to the value of a Github Personal Access Token and retry."
+    exit 1
+fi
+
+if [ $# -lt 3 ] || [ $# -gt 3 ]; then
+    echo "Usage: $0 <owner> <repo> <tag>"
+    echo
+    echo "where:"
+    echo "   <owner>: The repository scope organization. (required)"
+    echo "    <repo>: The repository name. (required)"
+    echo "     <tag>: The repository tag. (required)"
+    echo
+    echo "Examples:"
+    echo "    $0 pointfreeco swift-composable-architecture 1.18.0"
+    exit 1
+fi
+
+URL="https://api.github.com/repos/$1/$2/contents/?ref=$3"
+
+curl -H "X-GitHub-Api-Version: 2022-11-28" \
+     -H "Accept: application/vnd.github.object+json" \
+     -H "Authorization: Bearer $GITHUB_API_TOKEN" \
+     --no-progress-meter \
+     $URL

--- a/scripts/github-api-get-release-by-tag.sh
+++ b/scripts/github-api-get-release-by-tag.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# This calls the "Get A Release By Tag" Github API endpoint.
+# https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-a-release-by-tag-name
+#
+
+set -euo pipefail
+
+if [[ -z "${GITHUB_API_TOKEN+x}" ]]; then
+    echo "The environment variable GITHUB_API_TOKEN is not set."
+    echo "Please set GITHUB_API_TOKEN to the value of a Github Personal Access Token and retry."
+    exit 1
+fi
+
+if [ $# -lt 3 ] || [ $# -gt 3 ]; then
+    echo "Usage: $0 <owner> <repo> <tag>"
+    echo
+    echo "where:"
+    echo "   <owner>: The repository scope organization. (required)"
+    echo "    <repo>: The repository name. (required)"
+    echo "     <tag>: The repository tag. (required)"
+    echo
+    echo "Examples:"
+    echo "    $0 pointfreeco swift-composable-architecture 1.18.0"
+    exit 1
+fi
+
+URL="https://api.github.com/repos/$1/$2/releases/tags/$3"
+
+curl -H "X-GitHub-Api-Version: 2022-11-28" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: Bearer $GITHUB_API_TOKEN" \
+     --no-progress-meter \
+     $URL

--- a/scripts/github-api-get-repository.sh
+++ b/scripts/github-api-get-repository.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# This calls the "Get Repository" Github API endpoint.
+# https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#get-a-repository
+#
+
+set -euo pipefail
+
+if [[ -z "${GITHUB_API_TOKEN+x}" ]]; then
+    echo "The environment variable GITHUB_API_TOKEN is not set."
+    echo "Please set GITHUB_API_TOKEN to the value of a Github Personal Access Token and retry."
+    exit 1
+fi
+
+if [ $# -lt 2 ] || [ $# -gt 2 ]; then
+    echo "Usage: $0 <owner> <repo>"
+    echo
+    echo "where:"
+    echo "   <owner>: The repository scope organization. (required)"
+    echo "    <repo>: The repository name. (required)"
+    echo
+    echo "Examples:"
+    echo "    $0 pointfreeco swift-composable-architecture"
+    echo "    $0 swiftlang swift-syntax"
+    exit 1
+fi
+
+URL="https://api.github.com/repos/$1/$2"
+
+curl -H "X-GitHub-Api-Version: 2022-11-28" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: Bearer $GITHUB_API_TOKEN" \
+     --no-progress-meter \
+     $URL

--- a/scripts/github-api-get-tags.sh
+++ b/scripts/github-api-get-tags.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# This calls the "List Tags" Github API endpoint.
+#
+# https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repository-tags
+
+set -euo pipefail
+
+if [[ -z "${GITHUB_API_TOKEN+x}" ]]; then
+    echo "The environment variable GITHUB_API_TOKEN is not set."
+    echo "Please set GITHUB_API_TOKEN to the value of a Github Personal Access Token and retry."
+    exit 1
+fi
+
+if [ $# -lt 2 ] || [ $# -eq 3 ] || [ $# -gt 4 ]; then
+    echo "Usage: $0 <owner> <repo> [<per-page> <page>]"
+    echo
+    echo "where:"
+    echo "    <owner>: The repository scope organization. (required)"
+    echo "    <repo>:  The repository name. (required)"
+    echo "    <per-page>: Number of results per page. (optional)"
+    echo "    <page>: The page number of results to fetch. (optional)"
+    echo
+    echo "Examples:"
+    echo "    $0 pointfreeco swift-composable-architecture"
+    echo "    $0 swiftlang swift-syntax 100 2"
+    exit 1
+fi
+
+URL="https://api.github.com/repos/$1/$2/tags"
+
+if [ $# -eq 4 ]; then
+    URL="$URL?per_page=$3&page=$4"
+fi
+
+curl -H "X-GitHub-Api-Version: 2022-11-28" \
+     -H "Accept: application/vnd.github+json" \
+     -H "Authorization: Bearer $GITHUB_API_TOKEN" \
+     --no-progress-meter \
+     $URL

--- a/scripts/pr-download-source-archive.sh
+++ b/scripts/pr-download-source-archive.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Calls the downloadSourceArchive endpoint of a Swift Package Registry service running in localhost
+# https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/PackageRegistry/Registry.md#44-download-source-archive
+#
+
+set -euo pipefail
+
+if [ $# -lt 4 ] || [ $# -gt 4 ]; then
+    echo "Usage: $0 <scope> <name> <version> <zip>"
+    echo
+    echo "where:"
+    echo "   <scope>: The repository scope organization. (required)"
+    echo "    <name>: The repository name. (required)"
+    echo " <version>: The repository release version. (required)"
+    echo "     <zip>: The path to an output .zip file"
+    echo
+    echo "Examples:"
+    echo "    $0 pointfreeco swift-overture 0.5.0 swift-overture-0.5.0.zip"
+    exit 1
+fi
+
+URL="http://127.0.0.1:8080/$1/$2/$3.zip"
+
+curl --no-progress-meter -H "Accept: application/vnd.swift.registry.v1+zip" --output $4 $URL

--- a/scripts/pr-fetch-manifest.sh
+++ b/scripts/pr-fetch-manifest.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Calls the fetchManifest endpoint of a Swift Package Registry service running in localhost
+# https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/PackageRegistry/Registry.md#43-fetch-manifest-for-a-package-release
+#
+
+set -euo pipefail
+
+if [ $# -lt 3 ] || [ $# -gt 4 ]; then
+    echo "Usage: $0 <scope> <name> <version> [<swift-version>]"
+    echo
+    echo "where:"
+    echo "    <scope>: The repository scope organization. (required)"
+    echo "    <name>:  The repository name. (required)"
+    echo "    <version>: The repository release version. (required)"
+    echo "    <swift-version>: The swift version of the package manifest. (optional)"
+    echo
+    echo "Examples:"
+    echo "    $0 pointfreeco swift-composable-architecture 1.15.2"
+    echo "    $0 pointfreeco swift-composable-architecture 1.18.0 6.0"
+    exit 1
+fi
+
+URL="http://127.0.0.1:8080/$1/$2/$3/Package.swift"
+
+if [ $# -eq 4 ]; then
+    URL=$URL?swift-version=$4
+fi
+
+curl --no-progress-meter -H "Accept: application/vnd.swift.registry.v1+swift" $URL

--- a/scripts/pr-fetch-release-metadata.sh
+++ b/scripts/pr-fetch-release-metadata.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Calls the fetchReleaseMetadata endpoint of a Swift Package Registry service running in localhost
+# https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/PackageRegistry/Registry.md#42-fetch-information-about-a-package-release
+#
+
+set -euo pipefail
+
+if [ $# -lt 3 ] || [ $# -gt 3 ]; then
+    echo "Usage: $0 <scope> <name> <version>"
+    echo
+    echo "where:"
+    echo "    <scope>: The repository scope organization. (required)"
+    echo "     <name>: The repository name. (required)"
+    echo "  <version>: The semantic version of the repository (required)"
+    echo
+    echo "Examples:"
+    echo "    $0 pointfreeco swift-overture 0.5.0"
+    exit 1
+fi
+
+URL="http://127.0.0.1:8080/$1/$2/$3"
+
+curl --no-progress-meter -H "Accept: application/vnd.swift.registry.v1+json" $URL

--- a/scripts/pr-list-package-releases.sh
+++ b/scripts/pr-list-package-releases.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Calls the listPackageReleases endpoint of a Swift Package Registry service running in localhost
+# https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/PackageRegistry/Registry.md#41-list-package-releases
+#
+
+set -euo pipefail
+
+if [ $# -lt 2 ] || [ $# -eq 3 ] || [ $# -gt 4 ]; then
+    echo "Usage: $0 <scope> <name> [<per-page> <page>]"
+    echo
+    echo "where:"
+    echo "    <scope>: The repository scope organization. (required)"
+    echo "    <name>:  The repository name. (required)"
+    echo "    <per-page>: Number of results per page. (optional)"
+    echo "    <page>: The page number of results to fetch. (optional)"
+    echo
+    echo "Examples:"
+    echo "    $0 pointfreeco swift-composable-architecture"
+    echo "    $0 swiftlang swift-syntax 100 2"
+    exit 1
+fi
+
+URL="http://127.0.0.1:8080/$1/$2"
+
+if [ $# -eq 4 ]; then
+    URL="$URL?per_page=$3&page=$4"
+fi
+
+curl --no-progress-meter -H "Accept: application/vnd.swift.registry.v1+json" $URL

--- a/scripts/pr-lookup-identifiers.sh
+++ b/scripts/pr-lookup-identifiers.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Calls the lookupIdentifiers endpoint of a Swift Package Registry service running in localhost
+# https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/PackageRegistry/Registry.md#45-lookup-package-identifiers-registered-for-a-url
+#
+
+set -euo pipefail
+
+if [ $# -lt 2 ] || [ $# -gt 2 ]; then
+    echo "Usage: $0 <scope> <name>"
+    echo
+    echo "where:"
+    echo "   <scope>: The repository scope organization. (required)"
+    echo "    <name>: The repository name. (required)"
+    echo
+    echo "Examples:"
+    echo "    $0 pointfreeco swift-composable-architecture"
+    echo "    $0 apple swift-async-algorithms"
+    exit 1
+fi
+
+GITHUB_URL="https://github.com/$1/$2.git"
+URL="http://127.0.0.1:8080/identifiers?url=$GITHUB_URL"
+
+curl --no-progress-meter -H "Accept: application/vnd.swift.registry.v1+json" $URL


### PR DESCRIPTION
I had been using these shell scripts on my local machine to test:

* For example, when I made a change affecting a particular endpoint, then the `pr-*.sh` scripts helped me call that endpoint to test the change.
* Also, when I needed the double-check what the Github API response looked like, then the `github-api-*.sh` scripts helped me call the Github API.

I found these to be very useful, so I am adding them to the repository, along with some error checking to make sure the number of arguments are correct.

The `github-api-*.sh` scripts also verify that a `GITHUB_API_TOKEN` environment variable is set.