### PR TITLE
Use AsyncHTTPClientTransport instead of URLSessionTransport in GithubAPIClient

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "408cdf2b5fd1e598ab5c18b03230d378d806de662d49f6089093e8ceaecef67a",
+  "originHash" : "612fe284a371cc9004c6ff7985f90751251c3c048dd2ed910140deb667e936f6",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -317,6 +317,15 @@
       }
     },
     {
+      "identity" : "swift-openapi-async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-openapi-async-http-client.git",
+      "state" : {
+        "revision" : "915aeff168625b0f88a5810ee7ab8e9c00af671b",
+        "version" : "1.1.0"
+      }
+    },
+    {
       "identity" : "swift-openapi-generator",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-openapi-generator.git",
@@ -332,15 +341,6 @@
       "state" : {
         "revision" : "81c309c7b43cd56b2d2b90ca0170f17ff3d0c433",
         "version" : "1.8.1"
-      }
-    },
-    {
-      "identity" : "swift-openapi-urlsession",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-openapi-urlsession",
-      "state" : {
-        "revision" : "9bf4c712ad7989d6a91dbe68748b8829a50837e4",
-        "version" : "1.0.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -67,6 +67,7 @@ let package = Package(
                 .target(name: "GithubOpenAPI"),
                 .target(name: "ClientAuthMiddleware"),
                 .target(name: "ClientLoggingMiddleware"),
+                .target(name: "ClientStaticHeadersMiddleware"),
             ]
         ),
         .target(
@@ -88,6 +89,13 @@ let package = Package(
                 .product(name: "HTTPTypes", package: "swift-http-types"),
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
                 .product(name: "Vapor", package: "vapor"),
+            ]
+        ),
+        .target(
+            name: "ClientStaticHeadersMiddleware",
+            dependencies: [
+                .product(name: "HTTPTypes", package: "swift-http-types"),
+                .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
             ]
         ),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/vapor.git", from: "4.113.2"),
         .package(url: "https://github.com/apple/swift-openapi-generator", from: "1.7.1"),
         .package(url: "https://github.com/apple/swift-openapi-runtime", from: "1.8.1"),
-        .package(url: "https://github.com/apple/swift-openapi-urlsession", from: "1.0.2"),
+        .package(url: "https://github.com/swift-server/swift-openapi-async-http-client.git", from: "1.1.0"),
         .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.8.1"),
         .package(url: "https://github.com/apple/swift-http-types", from: "1.3.1"),
         .package(url: "https://github.com/swift-server/async-http-client", from: "1.25.2"),
@@ -42,7 +42,6 @@ let package = Package(
             name: "GithubOpenAPI",
             dependencies: [
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
-                .product(name: "OpenAPIURLSession", package: "swift-openapi-urlsession"),
             ],
             plugins: [
                 .plugin(name: "OpenAPIGenerator", package: "swift-openapi-generator"),
@@ -62,7 +61,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Dependencies", package: "swift-dependencies"),
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
-                .product(name: "OpenAPIURLSession", package: "swift-openapi-urlsession"),
+                .product(name: "OpenAPIAsyncHTTPClient", package: "swift-openapi-async-http-client"),
                 .target(name: "GithubAPIClient"),
                 .target(name: "GithubOpenAPI"),
                 .target(name: "ClientAuthMiddleware"),

--- a/Sources/ClientStaticHeadersMiddleware/ClientStaticHeadersMiddleware.swift
+++ b/Sources/ClientStaticHeadersMiddleware/ClientStaticHeadersMiddleware.swift
@@ -1,0 +1,26 @@
+import Foundation
+import HTTPTypes
+import OpenAPIRuntime
+
+public struct ClientStaticHeadersMiddleware {
+    let headers: [HTTPField.Name: String]
+
+    public init(headers: [HTTPField.Name: String] = [:]) {
+        self.headers = headers
+    }
+}
+
+extension ClientStaticHeadersMiddleware: ClientMiddleware {
+
+    public func intercept(
+        _ request: HTTPRequest,
+        body: HTTPBody?,
+        baseURL: URL,
+        operationID: String,
+        next: @Sendable (HTTPRequest, HTTPBody?, URL) async throws -> (HTTPResponse, HTTPBody?)
+    ) async throws -> (HTTPResponse, HTTPBody?) {
+        var request = request
+        headers.forEach { request.headerFields[$0.key] = $0.value }
+        return try await next(request, body, baseURL)
+    }
+}

--- a/Sources/GithubAPIClientImpl/GithubAPIClient+Live.swift
+++ b/Sources/GithubAPIClientImpl/GithubAPIClient+Live.swift
@@ -5,18 +5,18 @@ import Foundation
 import GithubOpenAPI
 import GithubAPIClient
 import OpenAPIRuntime
-import OpenAPIURLSession
+import OpenAPIAsyncHTTPClient
 
 extension GithubAPIClient {
 
     public static func live(
-        clientTransport: ClientTransport = URLSessionTransport(),
+        clientTransport: ClientTransport = AsyncHTTPClientTransport(),
         githubAPIToken: String? = ProcessInfo.processInfo.environment["GITHUB_API_TOKEN"]
     ) -> Self {
         var middlewares: [ClientMiddleware] = [
             ClientStaticHeadersMiddleware(
                 headers: [
-                    .userAgent: "GithubAPIClient GithubOpenAPI/1.1.4 URLSessionTransport/1.1.0"
+                    .userAgent: "GithubAPIClient GithubOpenAPI/1.1.4 AsyncHTTPClientTransport/1.1.0"
                 ]
             ),
             ClientLoggingMiddleware(bodyLoggingPolicy: .never),

--- a/Sources/GithubAPIClientImpl/GithubAPIClient+Live.swift
+++ b/Sources/GithubAPIClientImpl/GithubAPIClient+Live.swift
@@ -1,5 +1,6 @@
 import ClientAuthMiddleware
 import ClientLoggingMiddleware
+import ClientStaticHeadersMiddleware
 import Foundation
 import GithubOpenAPI
 import GithubAPIClient
@@ -13,6 +14,11 @@ extension GithubAPIClient {
         githubAPIToken: String? = ProcessInfo.processInfo.environment["GITHUB_API_TOKEN"]
     ) -> Self {
         var middlewares: [ClientMiddleware] = [
+            ClientStaticHeadersMiddleware(
+                headers: [
+                    .userAgent: "GithubAPIClient GithubOpenAPI/1.1.4 URLSessionTransport/1.1.0"
+                ]
+            ),
             ClientLoggingMiddleware(bodyLoggingPolicy: .never),
         ]
         if let githubAPIToken {


### PR DESCRIPTION
When you use [swift-openapi-generator](https://github.com/apple/swift-openapi-generator), your generated clients must be initialized with a `ClientTransport`. Apple and the Swift Community have two broadly supported implementations of `ClientTransport`:

- [swift-openapi-urlsession](https://github.com/apple/swift-openapi-urlsession) - a `ClientTransport` implemented the the venerable `URLSession` API
- [swift-openapi-async-http-client](https://github.com/swift-server/swift-openapi-async-http-client) - a `ClientTransport` implemented using `AsyncHTTPClient`

Between the two, both are supported on macOS and Linux, but swift-openapi-urlsession tends to be used in client applications more often, and swift-openapi-async-http-client is more often used in server applications (and is maintained by the [swift-server](https://github.com/swift-server) community. For example, Vapor uses `AsyncHTTPClient` extensively.

Therefore, it made sense to switch the `ClientTransport` we use to  [swift-openapi-async-http-client](https://github.com/swift-server/swift-openapi-async-http-client).

However, in the process, I discovered a minor issue:

* The Github API requires a `User-Agent` header
* The `URLSessionTransport` we were previously using automatically sets a `User-Agent` header. The `AsyncHTTPClientTransport` does not.
* So all of the Github API calls were failing with `403 Forbidden`.

So therefore, I added a `ClientStaticHeadersMiddleware` which allows us to set one or more static HTTP request headers on all `GithubAPIClient` requests. I used `ClientStaticHeadersMiddleware` to set the `User-Agent` header.