### PR TITLE
Move releaseMetadata.json into a DB table

### DIFF
--- a/Sources/App/Concurrency/DatabaseActor.swift
+++ b/Sources/App/Concurrency/DatabaseActor.swift
@@ -7,6 +7,7 @@ import Vapor
 actor DatabaseActor {
     private let repositorySemaphore = AsyncSemaphore(value: 1)
     private let manifestsSemaphore = AsyncSemaphore(value: 1)
+    private let packageReleaseSemaphore = AsyncSemaphore(value: 1)
 
     func addRepository(
         _ repository: GithubAPIClient.Repository,
@@ -124,6 +125,48 @@ actor DatabaseActor {
         logger.debug("Adding manifest to database: \(manifestToAdd).")
         try await manifestToAdd.create(on: database)
         logger.debug("Added manifest to database: \(manifestToAdd).")
+    }
+
+    func addPackageRelease(
+        _ packageRelease: PackageReleaseMetadata,
+        logger: Logger,
+        database: any Database
+    ) async throws {
+        await packageReleaseSemaphore.wait()
+        defer { packageReleaseSemaphore.signal() }
+
+        try await _addPackageRelease(packageRelease, logger: logger, database: database)
+    }
+
+    private func _addPackageRelease(
+        _ packageRelease: PackageReleaseMetadata,
+        logger: Logger,
+        database: any Database
+    ) async throws {
+        let packageReleaseCount = try await PackageRelease.query(on: database)
+            .filter(\.$packageScope == packageRelease.packageScope)
+            .filter(\.$packageName == packageRelease.packageName)
+            .filter(\.$packageVersion == packageRelease.packageVersion)
+            .count()
+        let packageReleaseId = "\(packageRelease.packageScope).\(packageRelease.packageName) \(packageRelease.packageVersion)"
+        guard packageReleaseCount == 0 else {
+            logger.debug("PackageRelease \(packageRelease.idText) already exists in database. Skipping database add.")
+            return
+        }
+
+        let packageReleaseToAdd = PackageRelease(
+            packageScope: packageRelease.packageScope,
+            packageName: packageRelease.packageName,
+            packageVersion: packageRelease.packageVersion,
+            tagName: packageRelease.tagName,
+            publishedAt: packageRelease.publishedAt,
+            zipBallURL: packageRelease.zipBallURL,
+            cacheFileName: packageRelease.cacheFileName,
+            checksum: packageRelease.checksum
+        )
+        logger.debug("Adding PackageRelease \(packageRelease.idText) to database.")
+        try await packageReleaseToAdd.create(on: database)
+        logger.debug("Added PackageRelease \(packageRelease.idText) to database.")
     }
 }
 

--- a/Sources/App/Concurrency/DatabaseActor.swift
+++ b/Sources/App/Concurrency/DatabaseActor.swift
@@ -148,7 +148,6 @@ actor DatabaseActor {
             .filter(\.$packageName == packageRelease.packageName)
             .filter(\.$packageVersion == packageRelease.packageVersion)
             .count()
-        let packageReleaseId = "\(packageRelease.packageScope).\(packageRelease.packageName) \(packageRelease.packageVersion)"
         guard packageReleaseCount == 0 else {
             logger.debug("PackageRelease \(packageRelease.idText) already exists in database. Skipping database add.")
             return

--- a/Sources/App/Controllers/PackageRegistryController+DownloadSourceArchive.swift
+++ b/Sources/App/Controllers/PackageRegistryController+DownloadSourceArchive.swift
@@ -8,8 +8,7 @@ import Vapor
 extension PackageRegistryController {
 
     func downloadSourceArchive(req: Request) async throws -> Response {
-        let logger = Logger(label: "downloadSourceArchive")
-        logger.debug("downloadSourceArchive(req: \(req))")
+        req.logger.debug("downloadSourceArchive(req: \(req))")
         let packageScopeAndName = try req.packageScopeAndName
         let packageVersion = try req.packageVersion
         try req.checkAcceptHeader(expectedMediaType: .zip)
@@ -22,37 +21,30 @@ extension PackageRegistryController {
 
         // Sync the release metadata. This sync fetches the source archive (zipBall)
         // from Github, caches it, and computes the checksum on it.
-        _ = try await releaseMetadataActor.loadData(
+        let releaseMetadata = try await releaseMetadataActor.loadData(
             owner: owner,
             repo: repo,
             version: version,
-            fileIO: req.fileio,
-            database: req.db,
-            logger: req.logger
+            req: req
         )
 
-        // Once we sync the release metadata, then the source
-        // archive should be cached. If it's not, that's an error.
-        guard let cachedSourceArchive = try await persistenceClient.readSourceArchive(owner: owner, repo: repo, version: version) else {
-            logger.error("Could not find expected cached source archive for \"\(owner).\(repo)\" version \(version).")
-            throw Abort(.internalServerError, title: "Could not load source archive from cache.")
-        }
+        // Get the cached file path to the source archive
+        let cachedSourceArchiveFilePath = Self.cachedSourceArchiveFilePath(
+            cacheRootDirectory: cacheRootDirectory,
+            sourceArchiveFileName: releaseMetadata.cacheFileName
+        )
 
-        logger.debug("Found cached source archive for \"\(owner).\(repo)\" version \(version). filePath=\"\(cachedSourceArchive.fileName)\"")
-
-        let response = try await req.fileio.asyncStreamFile(at: cachedSourceArchive.fileName) { result in
+        let response = try await req.fileio.asyncStreamFile(at: cachedSourceArchiveFilePath) { result in
             switch result {
             case .success:
-                logger.debug("Successfully streamed source archive file to response.")
+                req.logger.debug("Successfully streamed source archive file to response.")
             case .failure(let error):
-                logger.error("Error streaming source archive file to response: \(error)")
+                req.logger.error("Error streaming source archive file to response: \(error)")
             }
         }
 
-        let filePath = FilePath(cachedSourceArchive.fileName)
-        if let fileName = filePath.lastComponent?.string {
-            response.headers.add(name: .contentDisposition, value: "attachment; filename=\"\(fileName)\"")
-        }
+        let fileName = "\(owner)_\(repo)_\(version.description).zip"
+        response.headers.add(name: .contentDisposition, value: "attachment; filename=\"\(fileName)\"")
         response.headers.add(name: .contentVersion, value: SwiftRegistryAcceptHeader.Version.v1.rawValue)
 
         return response

--- a/Sources/App/Controllers/PackageRegistryController+FetchManifest.swift
+++ b/Sources/App/Controllers/PackageRegistryController+FetchManifest.swift
@@ -24,9 +24,7 @@ extension PackageRegistryController {
             owner: owner,
             repo: repo,
             version: version,
-            fileIO: req.fileio,
-            database: req.db,
-            logger: req.logger
+            req: req
         )
 
         let swiftMediaType = HTTPMediaType(type: "text", subType: "x-swift")

--- a/Sources/App/Controllers/PackageRegistryController+FetchReleaseMetadata.swift
+++ b/Sources/App/Controllers/PackageRegistryController+FetchReleaseMetadata.swift
@@ -22,9 +22,7 @@ extension PackageRegistryController {
             owner: owner,
             repo: repo,
             version: version,
-            fileIO: req.fileio,
-            database: req.db,
-            logger: req.logger
+            req: req
         )
 
         // Return the FetchReleaseMetadata

--- a/Sources/App/Controllers/PackageRegistryController+SyncManifests.swift
+++ b/Sources/App/Controllers/PackageRegistryController+SyncManifests.swift
@@ -164,8 +164,17 @@ extension PackageRegistryController {
     }
 
     static func manifestFilePath(cacheRootDirectory: String, manifestFileName: String) -> String {
-        "\(cacheRootDirectory)/manifests/\(manifestFileName)"
+        var path = cacheRootDirectory
+        if !path.hasSuffix("/") {
+            path += "/"
+        }
+        path += manifestsCacheDirectoryName
+        path += "/"
+        path += manifestFileName
+        return path
     }
+
+    static let manifestsCacheDirectoryName = "manifests"
 }
 
 private extension GithubAPIClient.GetContent.Output {

--- a/Sources/App/Controllers/PackageRegistryController+SyncManifests.swift
+++ b/Sources/App/Controllers/PackageRegistryController+SyncManifests.swift
@@ -15,31 +15,29 @@ extension PackageRegistryController {
         githubAPIClient: GithubAPIClient,
         tagsActor: TagsActor,
         databaseActor: DatabaseActor,
-        database: any Database,
-        fileIO: FileIO,
-        logger: Logger
+        req: Request
     ) async throws ->  [CachedPackageManifest] {
         // Attempt to read in all of the package manifests from db
-        let manifests = try await Manifest.query(on: database)
+        let manifests = try await Manifest.query(on: req.db)
             .filter(\.$packageScope == owner)
             .filter(\.$packageName == repo)
             .filter(\.$packageVersion == version.description)
             .all()
         guard manifests.isEmpty else {
-            logger.debug("Found \(manifests.count) cached manifests for \"\(owner).\(repo)\" version: \(version)")
+            req.logger.debug("Found \(manifests.count) cached manifests for \"\(owner).\(repo)\" version: \(version)")
             return manifests.map(\.asCachedPackageManifest)
         }
-        logger.debug("Did not find any cached manifests for \"\(owner).\(repo)\" version: \(version)")
+        req.logger.debug("Did not find any cached manifests for \"\(owner).\(repo)\" version: \(version)")
 
         // Get the cached tag information. Since the fetchManifest call
         // almost always comes after the listPackageReleases call in SPM, then
         // we assume that we already did a tag sync when the listPackageReleases
         // was called. So we don't force a sync now.
-        let tagFile = try await tagsActor.loadTagFile(owner: owner, repo: repo, forceSync: false, logger: logger)
+        let tagFile = try await tagsActor.loadTagFile(owner: owner, repo: repo, forceSync: false, logger: req.logger)
 
         // Look up the tag name for the requested semantic version
         guard let tagName = tagFile.versionToTagName[version] else {
-            logger.error("Could not find tag with semantic version \"\(version)\" for \"\(owner).\(repo)\".")
+            req.logger.error("Could not find tag with semantic version \"\(version)\" for \"\(owner).\(repo)\".")
             throw Abort(.internalServerError, title: "Could not find tag with semantic version \"\(version)\".")
         }
 
@@ -56,7 +54,7 @@ extension PackageRegistryController {
         guard !manifestFileNames.isEmpty else {
             throw Abort(.notFound, title: "No manifest files found.")
         }
-        logger.debug("Fetched repo root directory - found \(manifestFileNames.count) manifests for \"\(owner).\(repo)\" version: \(version)")
+        req.logger.debug("Fetched repo root directory - found \(manifestFileNames.count) manifests for \"\(owner).\(repo)\" version: \(version)")
         // Fetch all the manifests in parallel
         let fetchedManifests = try await withThrowingTaskGroup(of: PackageManifestWithContents.self, returning: [PackageManifestWithContents].self) { group in
             manifestFileNames.forEach { manifestFileName in
@@ -68,7 +66,7 @@ extension PackageRegistryController {
                         tagName: tagName,
                         manifestFileName: manifestFileName,
                         githubAPIClient: githubAPIClient,
-                        logger: logger
+                        logger: req.logger
                     )
                 }
             }
@@ -78,7 +76,7 @@ extension PackageRegistryController {
             }
             return manifests
         }
-        logger.debug("Fetched \(fetchedManifests.count) manifests for \"\(owner).\(repo)\" version: \(version)")
+        req.logger.debug("Fetched \(fetchedManifests.count) manifests for \"\(owner).\(repo)\" version: \(version)")
         // Write out all of the manifests in parallel
         let cachedPackageManifests = try await withThrowingTaskGroup(of: CachedPackageManifest.self, returning: [CachedPackageManifest].self) { group in
             fetchedManifests.forEach { fetchedManifest in
@@ -87,7 +85,7 @@ extension PackageRegistryController {
                         packageManifestWithContents: fetchedManifest,
                         cacheRootDirectory: cacheRootDirectory,
                         uuidGenerator: uuidGenerator,
-                        fileIO: fileIO
+                        fileIO: req.fileio
                     )
                 }
             }
@@ -100,8 +98,8 @@ extension PackageRegistryController {
         // Save the cached package manifests to the DB
         try await databaseActor.addCachedPackageManifests(
             cachedPackageManifests,
-            logger: logger,
-            database: database
+            logger: req.logger,
+            database: req.db
         )
 
         return cachedPackageManifests

--- a/Sources/App/Controllers/PackageRegistryController+SyncReleaseMetadata.swift
+++ b/Sources/App/Controllers/PackageRegistryController+SyncReleaseMetadata.swift
@@ -1,7 +1,9 @@
 import APIUtilities
+import AsyncHTTPClient
 import ChecksumClient
+import Dependencies
+import Fluent
 import GithubAPIClient
-import PersistenceClient
 import Vapor
 
 extension PackageRegistryController {
@@ -11,30 +13,43 @@ extension PackageRegistryController {
         repo: String,
         version: Version,
         githubAPIClient: GithubAPIClient,
-        persistenceClient: PersistenceClient,
         checksumClient: ChecksumClient,
-        logger: Logger,
-        tagsActor: TagsActor
-    ) async throws -> PersistenceClient.ReleaseMetadata {
-        if let cachedReleaseMetadata = try await persistenceClient.readReleaseMetadata(owner: owner, repo: repo, version: version) {
-            logger.debug("Found cached release metadata for \"\(owner).\(repo)\" version: \(version)")
-            return cachedReleaseMetadata
+        tagsActor: TagsActor,
+        databaseActor: DatabaseActor,
+        cacheRootDirectory: String,
+        uuidGenerator: UUIDGenerator,
+        req: Request
+    ) async throws -> PackageReleaseMetadata {
+        let packageRelease = try await PackageRelease.query(on: req.db)
+            .filter(\.$packageScope == owner)
+            .filter(\.$packageName == repo)
+            .filter(\.$packageVersion == version.description)
+            .first()
+        let releaseId = "\"\(owner).\(repo)\" \(version.description)"
+        if let packageRelease {
+            req.logger.debug("Found cached PackageRelease for \(releaseId)")
+            return packageRelease.asPackageReleaseMetadata
         } else {
-            logger.debug("Did not find cached release metadata for \"\(owner).\(repo)\" version: \(version)")
+            req.logger.debug("Did not find cached PackageRelease for \(releaseId)")
         }
 
         // Get the cached tag information. Since the fetchReleaseMetadata call
         // almost always comes after the listPackageReleases call in SPM, then
         // we assume that we already did a tag sync when the listPackageReleases
         // was called. So we don't force a sync now.
-        let tagFile = try await tagsActor.loadTagFile(owner: owner, repo: repo, forceSync: false, logger: logger)
+        let tagFile = try await tagsActor.loadTagFile(
+            owner: owner,
+            repo: repo,
+            forceSync: false,
+            logger: req.logger
+        )
 
         // Look up a tag with the requested semantic version
         guard
             let tagName = tagFile.versionToTagName[version],
             let tag = tagFile.tags.first(where: { $0.name == tagName })
         else {
-            logger.error("Could not find tag with semantic version \"\(version)\" for \"\(owner).\(repo)\".")
+            req.logger.error("Could not find tag with semantic version \"\(version)\" for \"\(owner).\(repo)\".")
             throw Abort(.internalServerError, title: "Could not find tag with semantic version \"\(version)\".")
         }
 
@@ -46,24 +61,91 @@ extension PackageRegistryController {
         // then pull out the publishedAt date to provide in the release metadata.
         // However, it is not an error if the "fetch release by tag name" fails - this
         // may be a tag with no corresponding release.
-        let publishedAt = try await githubAPIClient.getReleaseByTagName(.init(owner: owner, repo: repo, tag: tagName)).publishedAt
+        let input = GithubAPIClient.GetReleaseByTagName.Input(owner: owner, repo: repo, tag: tagName)
+        let publishedAt = try await githubAPIClient.getReleaseByTagName(input).publishedAt
 
         // Cache the zipBall
-        let zipBallPath = try await persistenceClient.saveSourceArchive(owner: owner, repo: repo, version: version, zipBallURL: tag.zipBallURL)
-        logger.debug("Downloaded \"\(tag.zipBallURL)\" to \"\(zipBallPath)\"")
+        let sourceArchiveFileName = "\(uuidGenerator().uuidString).zip"
+        let cachedSourceArchivePath = Self.cachedSourceArchiveFilePath(
+            cacheRootDirectory: cacheRootDirectory,
+            sourceArchiveFileName: sourceArchiveFileName
+        )
+        try await downloadSourceArchive(
+            url: tag.zipBallURL,
+            to: cachedSourceArchivePath,
+            httpClient: req.application.http.client.shared,
+            logger: req.logger
+        )
+        req.logger.debug("Downloaded \"\(tag.zipBallURL)\" to \"\(cachedSourceArchivePath)\"")
 
-        // Compute the checksum from the cached zipBall file
-        let checksum = try await checksumClient.computeFileChecksum(path: zipBallPath)
-        logger.debug("Computed checksum of \"\(zipBallPath)\" as \(checksum)")
+        // Compute the checksum from the cached source archive .zip file
+        let checksum = try await checksumClient.computeFileChecksum(path: cachedSourceArchivePath)
+        req.logger.debug("Computed checksum of \"\(cachedSourceArchivePath)\" as \(checksum)")
 
-        // Construct the ReleaseMetadata
-        let releaseMetadata = PersistenceClient.ReleaseMetadata(checksum: checksum, tag: tag, version: version, publishedAt: publishedAt)
+        // Construct the PackageReleaseMetadata
+        let packageReleaseMetadata = PackageReleaseMetadata(
+            packageScope: owner,
+            packageName: repo,
+            packageVersion: version.description,
+            tagName: tag.name,
+            publishedAt: publishedAt,
+            zipBallURL: tag.zipBallURL,
+            cacheFileName: sourceArchiveFileName,
+            checksum: checksum
+        )
 
-        // Cache the ReleaseMetadata
-        try await persistenceClient.saveReleaseMetadata(owner: owner, repo: repo, metadata: releaseMetadata)
-        logger.debug("Cached release metadata for \"\(owner).\(repo)\" version: \(version).")
+        // Write the PackageReleaseMetadata to the DB
+        try await databaseActor.addPackageRelease(packageReleaseMetadata, logger: req.logger, database: req.db)
+        req.logger.debug("Cached release metadata for \"\(owner).\(repo)\" version: \(version).")
 
-        return releaseMetadata
+        return packageReleaseMetadata
+    }
+
+    private static func downloadSourceArchive(
+        url: String,
+        to path: String,
+        httpClient: HTTPClient,
+        logger: Logger
+    ) async throws {
+        let request = try HTTPClient.Request(url: url)
+
+        let delegate = try FileDownloadDelegate(path: path, reportProgress: { progress in
+            if let totalBytes = progress.totalBytes {
+                logger.debug("Downloading: \(progress.receivedBytes) bytes of \(totalBytes)")
+            } else {
+                logger.debug("Downloading: \(progress.receivedBytes) bytes")
+            }
+        })
+
+        let progress = try await httpClient.execute(request: request, delegate: delegate, logger: logger).get()
+
+        if let totalBytes = progress.totalBytes {
+            logger.debug("Downloaded: \(progress.receivedBytes) bytes of \(totalBytes)")
+        } else {
+            logger.debug("Downloaded: \(progress.receivedBytes) bytes")
+        }
+    }
+
+    static func cachedSourceArchiveFilePath(
+        cacheRootDirectory: String,
+        sourceArchiveFileName: String
+    ) -> String {
+        "\(cacheRootDirectory)/sourceArchives/\(sourceArchiveFileName)"
+    }
+}
+
+private extension PackageRelease {
+    var asPackageReleaseMetadata: PackageReleaseMetadata {
+        .init(
+            packageScope: packageScope,
+            packageName: packageName,
+            packageVersion: packageVersion,
+            tagName: tagName,
+            publishedAt: publishedAt,
+            zipBallURL: zipBallURL,
+            cacheFileName: cacheFileName,
+            checksum: checksum
+        )
     }
 }
 

--- a/Sources/App/Controllers/PackageRegistryController.swift
+++ b/Sources/App/Controllers/PackageRegistryController.swift
@@ -22,7 +22,7 @@ struct PackageRegistryController: RouteCollection {
     let appLogger: Logger
     let getDateNow: GetDateNow
     let tagsActor: TagsActor
-    let releaseMetadataActor: MemoryCacheActor<PersistenceClient.ReleaseMetadata>
+    let releaseMetadataActor: MemoryCacheActor<PackageReleaseMetadata>
     let manifestsActor: MemoryCacheActor<[CachedPackageManifest]>
     let identifiersActor: IdentifiersActor
 
@@ -62,22 +62,24 @@ struct PackageRegistryController: RouteCollection {
             )
         }
 
-        let releaseMetadataActor = MemoryCacheActor { owner, repo, version, _, _, reqLogger in
+        let databaseActor = DatabaseActor()
+
+        let releaseMetadataActor = MemoryCacheActor { owner, repo, version, req in
             try await Self.syncReleaseMetadata(
                 owner: owner,
                 repo: repo,
                 version: version,
                 githubAPIClient: githubAPIClient,
-                persistenceClient: persistenceClient,
                 checksumClient: checksumClient,
-                logger: reqLogger,
-                tagsActor: tagsActor
+                tagsActor: tagsActor,
+                databaseActor: databaseActor,
+                cacheRootDirectory: cacheRootDirectory,
+                uuidGenerator: uuidGenerator,
+                req: req
             )
         }
 
-        let databaseActor = DatabaseActor()
-
-        let manifestsActor = MemoryCacheActor { owner, repo, version, fileIO, database, reqLogger in
+        let manifestsActor = MemoryCacheActor { owner, repo, version, req in
             try await Self.syncManifests(
                 owner: owner,
                 repo: repo,
@@ -87,9 +89,7 @@ struct PackageRegistryController: RouteCollection {
                 githubAPIClient: githubAPIClient,
                 tagsActor: tagsActor,
                 databaseActor: databaseActor,
-                database: database,
-                fileIO: fileIO,
-                logger: reqLogger
+                req: req
             )
         }
 

--- a/Sources/App/Controllers/PackageRegistryController.swift
+++ b/Sources/App/Controllers/PackageRegistryController.swift
@@ -75,6 +75,7 @@ struct PackageRegistryController: RouteCollection {
                 databaseActor: databaseActor,
                 cacheRootDirectory: cacheRootDirectory,
                 uuidGenerator: uuidGenerator,
+                githubAPIToken: githubAPIToken,
                 req: req
             )
         }

--- a/Sources/App/DataTransferObjects/PackageReleaseMetadata.swift
+++ b/Sources/App/DataTransferObjects/PackageReleaseMetadata.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct PackageReleaseMetadata: Equatable, Codable, Sendable {
+    var packageScope: String
+    var packageName: String
+    var packageVersion: String
+    var tagName: String
+    var publishedAt: Date?
+    var zipBallURL: String
+    var cacheFileName: String
+    var checksum: String
+}
+
+extension PackageReleaseMetadata {
+    var idText: String {
+        "\"\(packageScope).\(packageName)\" \(packageVersion)"
+    }
+}

--- a/Sources/App/Database/Migrations/CreatePackageReleases.swift
+++ b/Sources/App/Database/Migrations/CreatePackageReleases.swift
@@ -1,0 +1,22 @@
+import Fluent
+
+struct CreatePackageReleases: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("package_releases")
+            .id()
+            .field("package_scope", .string, .required)
+            .field("package_name", .string, .required)
+            .field("package_version", .string, .required)
+            .field("tag_name", .string, .required)
+            .field("published_at", .datetime)
+            .field("zip_ball_url", .string, .required)
+            .field("cache_file_name", .string, .required)
+            .field("checksum", .string, .required)
+            .unique(on: "package_scope", "package_name", "package_version")
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("package_releases").delete()
+    }
+}

--- a/Sources/App/Database/Models/PackageRelease.swift
+++ b/Sources/App/Database/Models/PackageRelease.swift
@@ -40,7 +40,7 @@ final class PackageRelease: Model, @unchecked Sendable {
         packageName: String,
         packageVersion: String,
         tagName: String,
-        publishedAt: Date,
+        publishedAt: Date?,
         zipBallURL: String,
         cacheFileName: String,
         checksum: String

--- a/Sources/App/Database/Models/PackageRelease.swift
+++ b/Sources/App/Database/Models/PackageRelease.swift
@@ -1,0 +1,58 @@
+import Fluent
+import Foundation
+import Vapor
+
+final class PackageRelease: Model, @unchecked Sendable {
+    static let schema = "package_releases"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "package_scope")
+    var packageScope: String
+
+    @Field(key: "package_name")
+    var packageName: String
+
+    @Field(key: "package_version")
+    var packageVersion: String
+
+    @Field(key: "tag_name")
+    var tagName: String
+
+    @OptionalField(key: "published_at")
+    var publishedAt: Date?
+
+    @Field(key: "zip_ball_url")
+    var zipBallURL: String
+
+    @Field(key: "cache_file_name")
+    var cacheFileName: String
+
+    @Field(key: "checksum")
+    var checksum: String
+
+    init() { }
+
+    init(
+        id: UUID? = nil,
+        packageScope: String,
+        packageName: String,
+        packageVersion: String,
+        tagName: String,
+        publishedAt: Date,
+        zipBallURL: String,
+        cacheFileName: String,
+        checksum: String
+    ) {
+        self.id = id
+        self.packageScope = packageScope
+        self.packageName = packageName
+        self.packageVersion = packageVersion
+        self.tagName = tagName
+        self.publishedAt = publishedAt
+        self.zipBallURL = zipBallURL
+        self.cacheFileName = cacheFileName
+        self.checksum = checksum
+    }
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -32,6 +32,7 @@ public func configure(
     // Add migrations
     app.migrations.add(CreateRepositories())
     app.migrations.add(CreateManifests())
+    app.migrations.add(CreatePackageReleases())
     if sqliteConfiguration.storage.isMemory {
         try await app.autoMigrate()
     }

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -22,8 +22,14 @@ enum Entrypoint {
         let httpStreamClient: HTTPStreamClient = .live()
         let cacheRootDirectory = app.directory.workingDirectory.appending(".sprsCache/")
         try await Self.ensureDirectoryExists(cacheRootDirectory)
-        let manifestsCacheDirectory = cacheRootDirectory.appending("manifests/")
+        let manifestsCacheDirectory = cacheRootDirectory
+            .appending(PackageRegistryController.manifestsCacheDirectoryName)
+            .appending("/")
         try await Self.ensureDirectoryExists(manifestsCacheDirectory)
+        let sourceArchivesCacheDirectory = cacheRootDirectory
+            .appending(PackageRegistryController.sourceArchivesCacheDirectoryName)
+            .appending("/")
+        try await Self.ensureDirectoryExists(sourceArchivesCacheDirectory)
         let dbPath = cacheRootDirectory.appending("db.sqlite")
         @Dependency(\.uuid) var uuid
         do {

--- a/Sources/PersistenceClient/PersistenceClient+Live.swift
+++ b/Sources/PersistenceClient/PersistenceClient+Live.swift
@@ -30,38 +30,6 @@ extension PersistenceClient {
                 encoder.outputFormatting = .default
                 let buffer = try encoder.encodeAsByteBuffer(tagFile, allocator: byteBufferAllocator)
                 try await fileClient.writeFile(buffer: buffer, path: path)
-            },
-            readSourceArchive: { owner, repo, version in
-                let cachedFileName = zipBallFileName(cacheRootDirectory: cacheRootDirectory, owner: owner, repo: repo, version: version)
-                return .init(fileName: cachedFileName)
-            },
-            saveSourceArchive: { owner, repo, version, zipBallURL in
-                // Fetch the entire zipBall into memory. TODO: Improve this by passing chunk-by-chunk into FileClient
-                let zipBytes = try await Self.fetchZipBall(url: zipBallURL, apiToken: githubAPIToken, httpStreamClient: httpStreamClient)
-                let cachedFileName = zipBallFileName(cacheRootDirectory: cacheRootDirectory, owner: owner, repo: repo, version: version)
-                try await fileClient.writeFile(buffer: zipBytes, path: cachedFileName)
-                return cachedFileName
-            },
-            readReleaseMetadata: { owner, repo, version in
-                let cachedFileName = releaseMetadataFileName(cacheRootDirectory: cacheRootDirectory, owner: owner, repo: repo, version: version)
-                let byteBuffer: ByteBuffer
-                do {
-                    byteBuffer = try await fileClient.readFile(path: cachedFileName)
-                } catch {
-                    // We failed to read the file. Return nil
-                    return nil
-                }
-                let decoder = JSONDecoder()
-                decoder.dateDecodingStrategy = .iso8601
-                return try decoder.decode(ReleaseMetadata.self, from: byteBuffer)
-            },
-            saveReleaseMetadata: { owner, repo, metadata in
-                let cachedFileName = releaseMetadataFileName(cacheRootDirectory: cacheRootDirectory, owner: owner, repo: repo, version: metadata.version)
-                let encoder = JSONEncoder()
-                encoder.dateEncodingStrategy = .iso8601
-                encoder.outputFormatting = .default
-                let byteBuffer = try encoder.encodeAsByteBuffer(metadata, allocator: byteBufferAllocator)
-                try await fileClient.writeFile(buffer: byteBuffer, path: cachedFileName)
             }
         )
     }
@@ -69,50 +37,6 @@ extension PersistenceClient {
     private static func tagsFileName(cacheRootDirectory: String, owner: String, repo: String) -> String {
         let cacheRootDirectoryWithSlash = cacheRootDirectory.ending(with: "/")
         return "\(cacheRootDirectoryWithSlash)\(owner)/\(repo)/tags.json"
-    }
-
-    private static func zipBallFileName(cacheRootDirectory: String, owner: String, repo: String, version: Version) -> String {
-        let cacheRootDirectoryWithSlash = cacheRootDirectory.ending(with: "/")
-        return "\(cacheRootDirectoryWithSlash)\(owner)/\(repo)/\(version)/\(owner)-\(repo)-\(version).zip"
-    }
-
-    private static func releaseMetadataFileName(cacheRootDirectory: String, owner: String, repo: String, version: Version) -> String {
-        let cacheRootDirectoryWithSlash = cacheRootDirectory.ending(with: "/")
-        return "\(cacheRootDirectoryWithSlash)\(owner)/\(repo)/\(version)/releaseMetadata.json"
-    }
-
-    private static func fetchZipBall(
-        url: String,
-        apiToken: String,
-        httpStreamClient: HTTPStreamClient
-    ) async throws -> ByteBuffer {
-        // Fetch the zipBallURL
-        var request = HTTPClientRequest(url: url)
-        request.headers.add(
-            name: "User-Agent",
-            value: "async-http-client/1.24.2"
-        )
-        request.headers.add(
-            name: "Authorization",
-            value: "Bearer \(apiToken)"
-        )
-        let response = try await httpStreamClient.execute(request)
-
-        guard response.status == .ok else {
-            throw PersistenceClientError.couldNotDownloadZipBall(Int(response.status.code))
-        }
-
-        // If defined, the content-length headers announces the size of the body
-        let maxBytes: Int
-        if let contentLength = response.headers.first(name: "Content-Length").flatMap(Int.init) {
-            maxBytes = contentLength
-        } else {
-            maxBytes = 1024 * 1024 * 1024
-        }
-
-        // For now, we just collect the whole zip file in memory and then
-        // return it to the response.
-        return try await response.body.collect(upTo: maxBytes)
     }
 }
 

--- a/Sources/PersistenceClient/PersistenceClient+Test.swift
+++ b/Sources/PersistenceClient/PersistenceClient+Test.swift
@@ -6,11 +6,7 @@ extension PersistenceClient {
 
     public static func test(
         readTags: (@Sendable (_ owner: String, _ repo: String) async throws -> TagFile)? = nil,
-        saveTags: (@Sendable (_ owner: String, _ repo: String, _ tagFile: TagFile) async throws -> Void)? = nil,
-        readSourceArchive: (@Sendable (_ owner: String, _ repo: String, _ version: Version) async throws -> SourceArchive?)? = nil,
-        saveSourceArchive: (@Sendable(_ owner: String, _ repo: String, _ version: Version, _ zipBallURL: String) async throws -> String)? = nil,
-        readReleaseMetadata: (@Sendable (_ owner: String, _ repo: String, _ version: Version) async throws -> ReleaseMetadata?)? = nil,
-        saveReleaseMetadata: (@Sendable (_ owner: String, _ repo: String, _ metadata: ReleaseMetadata) async throws -> Void)? = nil
+        saveTags: (@Sendable (_ owner: String, _ repo: String, _ tagFile: TagFile) async throws -> Void)? = nil
     ) -> Self {
         update(.mock) {
             if let readTags {
@@ -18,18 +14,6 @@ extension PersistenceClient {
             }
             if let saveTags {
                 $0.saveTags = saveTags
-            }
-            if let readSourceArchive {
-                $0.readSourceArchive = readSourceArchive
-            }
-            if let saveSourceArchive {
-                $0.saveSourceArchive = saveSourceArchive
-            }
-            if let readReleaseMetadata {
-                $0.readReleaseMetadata = readReleaseMetadata
-            }
-            if let saveReleaseMetadata {
-                $0.saveReleaseMetadata = saveReleaseMetadata
             }
         }
     }

--- a/Sources/PersistenceClient/PersistenceClient.swift
+++ b/Sources/PersistenceClient/PersistenceClient.swift
@@ -14,25 +14,6 @@ public struct PersistenceClient: Sendable {
     public var saveTags: @Sendable (_ owner: String, _ repo: String, _ tagFile: TagFile) async throws -> Void = { _, _, _ in
         reportIssue("\(Self.self).saveTags not implemented")
     }
-    /// Read the source archive for a single release for the specified owner, repo, and version
-    public var readSourceArchive: @Sendable (_ owner: String, _ repo: String, _ version: Version) async throws -> SourceArchive? = { _, _, _ in
-        reportIssue("\(Self.self).readSourceArchive not implemented")
-        return nil
-    }
-    /// Download the zipBallURL to cache and return the path to the cached zip file in the filesystem
-    public var saveSourceArchive: @Sendable(_ owner: String, _ repo: String, _ version: Version, _ zipBallURL: String) async throws -> String = { _, _, _, _ in
-        reportIssue("\(Self.self).saveSourceArchive not implemented")
-        return ""
-    }
-    /// Read the metadata (including zipBall checksum) for a single release for the specified owner, repo, and version
-    public var readReleaseMetadata: @Sendable (_ owner: String, _ repo: String, _ version: Version) async throws -> ReleaseMetadata? = { _, _, _ in
-        reportIssue("\(Self.self).readReleaseMetadata not implemented")
-        return nil
-    }
-    /// Save the metadata (including zipBall checksum) for a single release for the specified owner, repo, and version (version is inside `ReleaseMetadata`)
-    public var saveReleaseMetadata: @Sendable (_ owner: String, _ repo: String, _ metadata: ReleaseMetadata) async throws -> Void = { _, _, _ in
-        reportIssue("\(Self.self).saveReleaseMetadata not implemented")
-    }
 }
 
 public enum PersistenceClientError: Swift.Error {


### PR DESCRIPTION
This PR addresses issue https://github.com/CrowdStrike/swift-package-registry-service/issues/14.

Previously we would store release information in a `releaseMetadata.json` file in an appropriate directory. For example, for the request `GET /pointfreeco/swift-overture/0.5.0`, we would store `releaseMetadata.json` in the directory `<cache-root>/pointfreeco/swift-overture/`.

With this PR, we create a new DB table called `package_releases` and we store the equivalent information in that table.
